### PR TITLE
Fix Oracle Issues

### DIFF
--- a/Dapper.Contrib/Dapper.Contrib.csproj
+++ b/Dapper.Contrib/Dapper.Contrib.csproj
@@ -16,15 +16,29 @@
     <ProjectReference Include="..\Dapper\Dapper.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <PackageReference Include="Oracle.ManagedDataAccess">
+      <Version>12.2.1100</Version>
+    </PackageReference>
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <!-- TODO: fork dipdapdop/Dapper - this dep probably shouldn't be here (New Lib, Dapper.Contrib.Oracle -->
+  <!-- TODO: fork dipdapdop/Dapper - ODP.Net Beta
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Oracle.ManagedDataAccess" Version="12.2.1100" />
+  </ItemGroup>
+  ends -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Oracle.ManagedDataAccess">
+      <Version>12.2.1100</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/Dapper.Contrib/OracleDynamicParameters.cs
+++ b/Dapper.Contrib/OracleDynamicParameters.cs
@@ -1,8 +1,8 @@
-﻿#if !COREFX
+﻿#if !NETSTANDARD1_3 || NETSTANDARD2_0
 //
 // Fork of https://github.com/vijaysg
 // https://gist.github.com/vijaysg/3096151
-// Extends dapper-dot-net
+// Extends StackOverflow/Dapper
 // + Caren Wong (CW), + Shaun McGrath (SIM)
 //
 

--- a/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
+++ b/Dapper.Tests.Contrib/Dapper.Tests.Contrib.csproj
@@ -6,7 +6,9 @@
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <!--<TargetFrameworks>netcoreapp1.0;netcoreapp2.0</TargetFrameworks>-->
+    <!-- SIM: Oracle.ManagedDataAccess incompatible with netcoreapp2.0 -->
+    <TargetFrameworks>netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Dapper.Tests\Helpers\XunitSkippable.cs;..\Dapper\TypeExtensions.cs" />

--- a/Dapper.Tests/Dapper.Tests.csproj
+++ b/Dapper.Tests/Dapper.Tests.csproj
@@ -6,7 +6,9 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
-    <TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <!--<TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>-->
+    <!-- TODO: Oracle.ManagedDataAccess not compatible with netcoreapp2.0  -->
+    <TargetFrameworks>net452;netcoreapp1.0;</TargetFrameworks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
Add Dapper.Contrib ref to ODP.Net (at `net461`). Temporarily remove `netcoreapp2.0` platform build as ODP.Net not compatible (wait for ODP.Net public beta.